### PR TITLE
Add website when create oauth application

### DIFF
--- a/src/mastodon.js
+++ b/src/mastodon.js
@@ -299,12 +299,14 @@ class Mastodon {
     static createOAuthApp(url = DEFAULT_OAUTH_APPS_ENDPOINT,
                           clientName = 'mastodon-node',
                           scopes = 'read write follow',
-                          redirectUri = 'urn:ietf:wg:oauth:2.0:oob') {
+                          redirectUri = 'urn:ietf:wg:oauth:2.0:oob',
+                          webSite = null) {
         return new Promise((resolve, reject) => {
             Request.post({
                 url,
                 form: {
                     client_name: clientName,
+                    website: webSite,
                     redirect_uris: redirectUri,
                     scopes
                 }


### PR DESCRIPTION
I want to register my application URL when create oauth app.
And mastodon already has an API to accept the website URL.

So, I add `webSite` option at `createOAuthApp`.