### PR TITLE
Add resolution of natives for node v10.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,5 +46,8 @@
     "gulp": "^3.9.1",
     "gulp-babel": "^6.1.2",
     "gulp-clean": "^0.3.2"
+  },
+  "resolutions": {
+    "natives": "1.1.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2302,9 +2302,9 @@ mute-stream@0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.5.tgz#8fbfabb0a98a253d3184331f9e8deb7372fac6c0"
 
-natives@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/natives/-/natives-1.1.0.tgz#e9ff841418a6b2ec7a495e939984f78f163e6e31"
+natives@1.1.3, natives@^1.1.0:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/natives/-/natives-1.1.3.tgz#44a579be64507ea2d6ed1ca04a9415915cf75558"
 
 natural-compare@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
Now TravisCI failed on node v10.x, because of `natives`.
https://github.com/gulpjs/gulp/issues/2162

So I add resolution of natives.