### PR TITLE
Allow PATCH and PUT as HTTP methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,6 @@
     "gulp-clean": "^0.3.2"
   },
   "resolutions": {
-    "natives": "1.1.3"
+    "natives": "1.1.6"
   }
 }

--- a/src/mastodon.js
+++ b/src/mastodon.js
@@ -29,8 +29,16 @@ class Mastodon {
         return this.request('GET', path, params, callback)
     }
 
+    patch(path, params, callback) {
+        return this.request('PATCH', path, params, callback)
+    }
+
     post(path, params, callback) {
         return this.request('POST', path, params, callback)
+    }
+
+    put(path, params, callback) {
+        return this.request('PUT', path, params, callback)
     }
 
     delete(path, params, callback) {
@@ -39,7 +47,7 @@ class Mastodon {
 
     request(method, path, params, callback) {
         const self = this
-        assert(method === 'GET' || method === 'POST' || method === 'DELETE')
+        assert(method === 'GET' || method === 'PATCH' || method === 'POST' || method === 'PUT' || method === 'DELETE')
         // if no `params` is specified but a callback is, use default params
         if (typeof params === 'function') {
             callback = params


### PR DESCRIPTION
Some Mastodon requests require the HTTP methods PATCH and PUT.

* `PUT` https://docs.joinmastodon.org/api/rest/filters/#put-api-v1-filters-id
* `PATCH` https://docs.joinmastodon.org/api/rest/accounts/#patch-api-v1-accounts-update-credentials

The current code throws an error when sending such requests. That is why I allowed those methods and added separate functions for them.