### PR TITLE
add json-bigint to parse big activitypub_id

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   ],
   "dependencies": {
     "gulp-eslint": "^3.0.1",
+    "json-bigint": "^0.3.0",
     "mime": "^1.3.4",
     "oauth": "^0.9.15",
     "readline": "^1.3.0",

--- a/src/mastodon.js
+++ b/src/mastodon.js
@@ -2,6 +2,7 @@ import assert from 'assert'
 import util from 'util'
 import { OAuth2 } from 'oauth'
 import Request from 'request'
+import JSONbig from 'json-bigint'
 
 import Helpers from './helpers'
 import StreamingAPIConnection from './streaming-api-connection'
@@ -204,7 +205,7 @@ class Mastodon {
             request.on('end', () => {
                 if (body !== '') {
                     try {
-                        body = JSON.parse(body)
+                        body = JSONbig.parse(body)
                     } catch (jsonDecodeError) {
                         // there was no transport-level error,
                         // but a JSON object could not be decoded from the request body
@@ -324,7 +325,7 @@ class Mastodon {
                     return
                 }
                 try {
-                    body = JSON.parse(body)
+                    body = JSONbig.parse(body)
                 } catch (e) {
                     reject(new Error(`Error parsing body ${body}`))
                 }

--- a/src/parser.js
+++ b/src/parser.js
@@ -1,4 +1,5 @@
 import { EventEmitter } from 'events'
+import JSONbig from 'json-bigint'
 
 class Parser extends EventEmitter {
 
@@ -46,7 +47,7 @@ class Parser extends EventEmitter {
                 let data = root[1].substr(6)
 
                 try {
-                    data = JSON.parse(data)
+                    data = JSONbig.parse(data)
                 } catch (err) {
                     this.emit('error', new Error(`Error parsing API reply: '${piece}', error message: '${err}'`))
                 } finally {

--- a/src/streaming-api-connection.js
+++ b/src/streaming-api-connection.js
@@ -1,11 +1,12 @@
 import Request from 'request'
-
 import { EventEmitter } from 'events'
+import JSONbig from 'json-bigint'
 
 import Helpers from './helpers'
 import Parser from './parser'
 
 import { STATUS_CODES_TO_ABORT_ON } from './settings'
+
 
 class StreamingAPIConnection extends EventEmitter {
 
@@ -79,7 +80,7 @@ class StreamingAPIConnection extends EventEmitter {
                     body += chunk.toString('utf8')
 
                     try {
-                        body = JSON.parse(body)
+                        body = JSONbig.parse(body)
                     } catch (jsonDecodeError) {
                         // if non-JSON text was returned, we'll just attach it to the error as-is
                     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -630,6 +630,11 @@ beeper@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/beeper/-/beeper-1.1.1.tgz#e6d5ea8c5dad001304a70b22638447f69cb2f809"
 
+bignumber.js@^7.0.0:
+  version "7.2.1"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-7.2.1.tgz#80c048759d826800807c4bfd521e50edbba57a5f"
+  integrity sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ==
+
 boom@2.x.x:
   version "2.10.1"
   resolved "https://registry.yarnpkg.com/boom/-/boom-2.10.1.tgz#39c8918ceff5799f83f9492a848f625add0c766f"
@@ -1885,6 +1890,13 @@ jsesc@~0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
 
+json-bigint@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/json-bigint/-/json-bigint-0.3.0.tgz#0ccd912c4b8270d05f056fbd13814b53d3825b1e"
+  integrity sha1-DM2RLEuCcNBfBW+9E4FLU9OCWx4=
+  dependencies:
+    bignumber.js "^7.0.0"
+
 json-schema@0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
@@ -2302,9 +2314,10 @@ mute-stream@0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.5.tgz#8fbfabb0a98a253d3184331f9e8deb7372fac6c0"
 
-natives@1.1.3, natives@^1.1.0:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/natives/-/natives-1.1.3.tgz#44a579be64507ea2d6ed1ca04a9415915cf75558"
+natives@1.1.6, natives@^1.1.0:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/natives/-/natives-1.1.6.tgz#a603b4a498ab77173612b9ea1acdec4d980f00bb"
+  integrity sha512-6+TDFewD4yxY14ptjKaS63GVdtKiES1pTPyxn9Jb0rBqPMZ7VcCiooEhPNsr+mqHtMGxa/5c/HhcC4uPEUw/nA==
 
 natural-compare@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
the largest number Javascript can represent is 2^53 while
activitypub_id in mastodon could reach 2^64

waiting for a better BigInt support in javascript (see https://github.com/tc39/proposal-bigint)
I'm using json-bigint to parse JSON and correctly retrieve activitypub_id