### PR TITLE
Actually catch/surface transport-level errors

### DIFF
--- a/src/mastodon.js
+++ b/src/mastodon.js
@@ -230,25 +230,24 @@ class Mastodon {
                 // success case - no errors in HTTP response body
                 callback(null, body, response)
             })
+        })
 
-
-            request.on('error', (err) => {
-                // transport-level error occurred - likely a socket error
-                if (mastodonOptions.retry
-                    && STATUS_CODES_TO_ABORT_ON.includes(err.statusCode)) {
-                    // retry the request since retries were specified
-                    // and we got a status code we should retry on
-                    // FIXME
-                    // this.request(method, path, params, callback);
-                } else {
-                    // pass the transport-level error to the caller
-                    err.statusCode = null
-                    err.code = null
-                    err.allErrors = []
-                    err = Helpers.attachBodyInfoToError(err, body)
-                    callback(err, body, response)
-                }
-            })
+        request.on('error', (err) => {
+            // transport-level error occurred - likely a socket error
+            if (mastodonOptions.retry
+                && STATUS_CODES_TO_ABORT_ON.includes(err.statusCode)) {
+                // retry the request since retries were specified
+                // and we got a status code we should retry on
+                // FIXME
+                // this.request(method, path, params, callback);
+            } else {
+                // pass the transport-level error to the caller
+                err.statusCode = null
+                err.code = null
+                err.allErrors = []
+                err = Helpers.attachBodyInfoToError(err, body)
+                callback(err, body, response)
+            }
         })
     }
 


### PR DESCRIPTION
Setting `.on('error')` listener within `.on('respone')` block lead to unhandled exceptions from underlying Request events for e.g. `CERT_HAS_EXPIRED`.

Breaking this out so listener attaches appropriately and errors are caught/surfaced as intended. Misbehavior discovered and submitted fix tested in production backend of cheapbotstootsweet.com.


**Sample call:**
```
async function sendToot(params, M) {
  let {data, resp} = await M.post('/statuses', params).catch((err)=>console.error(err));
  return data;
}

async function runTest() {
  let tootData = await sendToot({status: "testing", visibility: "public"}, new Mastodon(CREDENTIALS));
  console.log("We made it past the error!");
}

runTest();
```


**Behavior __before__ PR:**
```
 throw er; // Unhandled 'error' event
      ^

Error: certificate has expired
    at TLSSocket.onConnectSecure (node:_tls_wrap:1498:34)
    at TLSSocket.emit (node:events:376:20)
    at TLSSocket._finishInit (node:_tls_wrap:933:8)
    at TLSWrap.ssl.onhandshakedone (node:_tls_wrap:707:12)
Emitted 'error' event on Request instance at:
    at Request.onRequestError (/opt/cbts/prod/traceryhosting-backend/node_modules/request/request.js:881:8)
    at ClientRequest.emit (node:events:376:20)
    at TLSSocket.socketErrorListener (node:_http_client:490:9)
    at TLSSocket.emit (node:events:376:20)
    at emitErrorNT (node:internal/streams/destroy:188:8)
    at emitErrorCloseNT (node:internal/streams/destroy:153:3)
    at processTicksAndRejections (node:internal/process/task_queues:80:21) {
  code: 'CERT_HAS_EXPIRED'
}
```


**Behavior __after__ PR:**
```
Error: certificate has expired
    at TLSSocket.onConnectSecure (node:_tls_wrap:1498:34)
    at TLSSocket.emit (node:events:376:20)
    at TLSSocket._finishInit (node:_tls_wrap:933:8)
    at TLSWrap.ssl.onhandshakedone (node:_tls_wrap:707:12) {
  code: 'CERT_HAS_EXPIRED',
  allErrors: [],
  mastodonReply: ''
}
We made it past the error!
```
