### PR TITLE
Fix #34: don't JSON.parse delete events' IDs

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -45,7 +45,9 @@ class Parser extends EventEmitter {
                 let data = root[1].substr(6)
 
                 try {
-                    data = JSON.parse(data)
+                    if (event !== 'delete') {
+                        data = JSON.parse(data)
+                    }
                 } catch (err) {
                     this.emit('error', new Error(`Error parsing API reply: '${piece}', error message: '${err}'`))
                 } finally {


### PR DESCRIPTION
Per discussion in #34, we shouldn't `JSON.parse` `delete` events' payload because it's a stringy ID and needs to remain a string to avoid exceeding float precision issues.

This appears to be the only event for which this is the case, per [Mastodon docs](https://docs.joinmastodon.org/methods/streaming/#events) (no other events mention `string ID`). Therefore, this PR proposes a simple solution: skip `JSON.parse`ing the event payload if it's a delete.

With this in place, the following streaming data chunk:
```
event: delete\ndata: 110988741790818968\n\n
```
is parsed into `{ event: 'delete', data: '110988741790818968' }` as expected (and not `parseInt('110988741790818968')` which is 110988741790818980…). All other events are processed as before.